### PR TITLE
fix: scrollHander loads after window has finished loading

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -12,10 +12,7 @@ function scrollHandler(e) {
   const line = qs(".line");
   console.log(line);
   line.style.bottom = `calc(100% - 20px)`;
-
-  console.log(line);
-  line.style.bottom = `calc(100% - 20px)`;
-
+  line.style.display = "block";
   const targetY = window.innerHeight * 0.8;
   let prevScrollY = window.scrollY;
   let up, down;
@@ -52,6 +49,6 @@ function scrollHandler(e) {
   prevScrollY = window.scrollY;
 }
 
-scrollHandler();
-line.style.display = "block";
+window.onload = () => scrollHandler();
+
 window.addEventListener("scroll", scrollHandler);


### PR DESCRIPTION
Der Fehler war dass scrollHandler() direkt und nicht bei window.onload ausgeführt wurde, dadurch war das line Element null und warf einen Fehler.